### PR TITLE
Add Onboarding/Offboarding doc

### DIFF
--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -1,0 +1,64 @@
+# Onboarding/Offboarding
+
+## How to onboard someone in KOSS?
+
+See also [Fresher's Induction](/docs/community/freshers-induction).
+
+1. Add them to the “Newbies” GitHub team.
+1. Add them to the Google Group. Check the delivery settings.
+1. Add them to the Slack.
+1. Add them to their batch’s private channel.
+1. Add their contact details on https://github.com/kossiitkgp/secrets
+1. Assign their 1:1 group
+1. Add their name to the website
+1. Add them to facebook groups (unofficial)
+1. Give access to KOSS’ facebook page
+1. Make them store numbers of everyone in team
+
+## How to re-designate Core Team Members as Executives?
+1. Make Executive Members the Admins of Slack workspace.
+1. Make Executive Heads the Owners of Slack workspace.
+1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
+1. Change role of Executive Heads as `Maintainers` of the GitHub org.
+1. Make Executive Heads the Owners of the Google Group.
+1. Update Contacts README on `kossiitkgp/secrets`
+1. Release the names from blog/facebook page
+1. Update the “Members” section on the website
+
+## How to offboard someone from KOSS?
+
+1. Remove them from the GitHub organization.
+1. Disable their account on Slack (Contact an owner if they are admin)
+1. Remove them from the Google group
+1. Update the Contacts on https://github.com/kossiitkgp/secrets
+1. Update the “Members” section on the website - https://kossiitkgp.org
+1. Remove access to KOSS’ facebook page
+1. Remove their listing from website
+1. Remove them from facebook groups (if any)
+
+## Why do we lay off some Core Team members? What are the reasons?
+
+A bad influence justifies bad turn of events in the future. When they become an advisor, they will recruit similar kind of people. New Core Team Members will start following them. Hence, we can not be passive about the membership of a CTM. We have to make sure we purge any unwanted behavior in time. Hence, it is important that we keep the doors open until a CTM becomes an Executive.
+
+1. If they do not align with our vision. Read [Founding Principles of KOSS](/docs/founding-principles).
+1. If they often do not show up in Meetings, Slack, or E-mails.
+1. If they never take ownership of KOSS.
+  1. If they repeatatively do not care about how our meetings or events happen in their absense.
+1. If they never take leadership of KOSS. If they never take any initiatives or never took part in any initiative by one of their batchmates.
+  1. If they depend upon their batchmates all the time. If they never volunteer and take up any work by their own.
+1. If they clearly feel or state that they do not belong here.
+
+Note: One semester may not be enough to judge. Preferably do it after [Governance Review Week](/docs/community/governance-review-week).
+
+
+## How do we classify a CTM as Executive Head and Executive Member?
+
+The answer to this question should come from - the [Governance doc](/docs/community/governance).
+
+After the Governance Review Week, all Executives and Advisors meet and decide for each CTM. Here are some guidelines -
+
+1. Read the governance doc thoroughly and judge.
+1. An Executive Head must be self-motivated about KOSS.
+1. An Executive Head must be capable of leading a new batch of KOSS.
+1. Think about all the new Executive Heads as a group. Their should not be any friction in it.
+1. Do not select a scary low number of Heads. Keep it 3-6.


### PR DESCRIPTION
**Write path(s) which will be affected by this Pull Request.**
- `/community/onboarding-offboarding`

**Justify your changes or addition.**
Added steps necessary to onboard new members. A separate `/community/freshers-induction` doc will be created for the process, motivation and efficiency of onboarding freshers. There are steps for offboarding members as well. There are steps needed to be taken by an Admin to re-designate a CTM to an Executive.

**Why do you think it should be documented?**
We have a lot of internet accounts. It is not possible to remember each and every step which is supposed to be done in these cases. It is a wise idea to write them down.