### PR TITLE
Owners of GitHub org

### DIFF
--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -19,6 +19,7 @@ See also [Fresher's Induction](/docs/community/freshers-induction).
 1. Make Executive Members the Admins of Slack workspace.
 1. Make Executive Heads the Owners of Slack workspace.
 1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
+1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as Owners.
 1. Change role of Executive Heads as `Maintainers` of the GitHub org.
 1. Make Executive Heads the Owners of the Google Group.
 1. Update Contacts README on `kossiitkgp/secrets`

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -19,8 +19,7 @@ See also [Fresher's Induction](/docs/community/freshers-induction).
 1. Make Executive Members the Admins of Slack workspace.
 1. Make Executive Heads the Owners of Slack workspace.
 1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
-1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as Owners.
-1. Change role of Executive Heads as `Maintainers` of the GitHub org.
+1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as `Owners`.
 1. Make Executive Heads the Owners of the Google Group.
 1. Update Contacts README on `kossiitkgp/secrets`
 1. Release the names from blog/facebook page


### PR DESCRIPTION
Add an instruction to make Executive Heads the owners of GitHub org. This is in addition to adding them to the Admins team.

**Write path(s) which will be affected by this Pull Request.**
- `/community/onboarding-offboarding`

**Justify your changes or addition.**
Just adding them to the Admins team does not give them special powers like adding or removing people from the org.

**Why do you think it should be documented?**
Eh, we didn't know about this until today. So, this should we documented.
