### PR TITLE
Add fb page roles, fix fullstop inconsistency

### DIFF
--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -12,39 +12,40 @@ See also [Fresher's Induction](/docs/community/freshers-induction).
 1. Add them to the Google Group. Check the delivery settings.
 1. Add them to the Slack.
 1. Add them to their batch’s private channel.
-1. Add their contact details on https://github.com/kossiitkgp/secrets
-1. Assign their 1:1 group
-1. Add their name to the website
+1. Add their contact details on https://github.com/kossiitkgp/secrets .
+1. Assign their 1:1 group.
+1. Add their name to the website.
 1. Add them to facebook groups (unofficial)
-1. Give access to KOSS’ facebook page
-1. Make them store numbers of everyone in team
+1. Give access to KOSS’s facebook page.
+1. Make them store numbers of everyone in team.
 
 ## How to re-designate Core Team Members as Executives?
 1. Make all Executives the Admins of Slack workspace.
 1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
 1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as `Owners`.
 1. Make Executive Heads the Managers of the Google Group.
-1. Update Contacts README on `kossiitkgp/secrets`
-1. Release the names from blog/facebook page
-1. Update the “Members” section on the website
+1. Make all Executives the Admins of the Facebook Page.
+1. Update Contacts README on `kossiitkgp/secrets`.
+1. Release the names from blog/facebook page.
+1. Update the “Members” section on the website.
 
 ## How to re-designate Executive Members as Advisors?
 1. Make all Advisors the Owners of Slack workspace.
 1. Make all Advisors the Owners of the Google Group.
-1. Update Contacts README on `kossiitkgp/secrets`
-1. Update the “Members” section on the website
+1. Update Contacts README on `kossiitkgp/secrets`.
+1. Update the “Members” section on the website.
 
 
 ## How to offboard someone from KOSS?
 
 1. Remove them from the GitHub organization.
-1. Disable their account on Slack (Contact an owner if they are admin)
-1. Remove them from the Google group
-1. Update the Contacts on https://github.com/kossiitkgp/secrets
-1. Update the “Members” section on the website - https://kossiitkgp.org
-1. Remove access to KOSS’ facebook page
-1. Remove their listing from website
-1. Remove them from facebook groups (if any)
+1. Disable their account on Slack (Contact an owner if they are admin).
+1. Remove them from the Google group.
+1. Update the Contacts on https://github.com/kossiitkgp/secrets .
+1. Update the “Members” section on the website - https://kossiitkgp.org .
+1. Remove access to KOSS’ facebook page.
+1. Remove their listing from website.
+1. Remove them from facebook groups (if any).
 
 ## Why do we lay off some Core Team members? What are the reasons?
 
@@ -53,9 +54,9 @@ A bad influence justifies bad turn of events in the future. When they become an 
 1. If they do not align with our vision. Read [Founding Principles of KOSS](/docs/founding-principles).
 1. If they often do not show up in Meetings, Slack, or E-mails.
 1. If they never take ownership of KOSS.
-  1. If they repeatatively do not care about how our meetings or events happen in their absense.
+1. If they repeatatively do not care about how our meetings or events happen in their absense.
 1. If they never take leadership of KOSS. If they never take any initiatives or never took part in any initiative by one of their batchmates.
-  1. If they depend upon their batchmates all the time. If they never volunteer and take up any work by their own.
+1. If they depend upon their batchmates all the time. If they never volunteer and take up any work by their own.
 1. If they clearly feel or state that they do not belong here.
 
 Note: One semester may not be enough to judge. Preferably do it after [Governance Review Week](/docs/community/governance-review-week).


### PR DESCRIPTION
Updated `community/onboarding/offboarding.md` , to precisely mention that Executives to be made admins for Facebook page roles.

**Justify your changes or addition.** -> Executives will have all rights to FB pages including onboarding new members to FB pages (CTMs in this case), while themselves being easy to be offboarded. Since in FB page roles, Admins can be easily removed by other Admins.

Also, fixed full stop inconsistency. :upside_down_face: 

This PR is in continuation to #18.