### PR TITLE
Update README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,4 +9,4 @@ KOSS Documentation is meant to be read and followed by the members of KOSS. We k
 
 # How is KOSS Documentation published?
 
-The repository https://github.com/kossiitkgp/kossiitkgp.org uses this repository as a submodule to publish. If you make changes here, you will need to updated https://github.com/kossiitkgp/kossiitkgp.org to get it published.
+The repository https://github.com/kossiitkgp/kossiitkgp.github.io uses this repository as a submodule to publish. If you make changes here, you will need to updated https://github.com/kossiitkgp/kossiitkgp.github.io to get it published.


### PR DESCRIPTION
# PR to fix the [Broken link] in README.md #21 
The Links of the Github Repository hosting the page is corrected. The link is now working and will redirect user to the required Github repository
