### PR TITLE
Added docs related to recruitment

### DIFF
--- a/community/_index.md
+++ b/community/_index.md
@@ -6,3 +6,4 @@ All the docs related to the closed community of KOSS.
 - [Governance](governance)
 - [Onboarding/Offboarding](onboarding-offboarding)
 - [1:1](one-on-one)
+- [Recruitment](recruitment)

--- a/community/recruitment.md
+++ b/community/recruitment.md
@@ -13,8 +13,8 @@ For more detailed description, refer [Freshers' Selection](/docs/events/freshers
 ## Do we accept M.Tech and Ph.D students?
 No. By acceptance, we mean that they will hold a number of responsibilities
 - Attend our meetings
-- Participate in our workshops and their logistics
+- Participate in conducting our workshops and help with the required logistics
 - Collaborate on projects together
 - Be an active member of the society
 
-However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If they want to talk about something, we can have them in one of your meetings as well. There are no such rules preventing the same.
+However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If they want to talk about something, we can have them in one of our meetings as well.

--- a/community/recruitment.md
+++ b/community/recruitment.md
@@ -1,0 +1,20 @@
++++
+toc=true
++++
+
+# Recruitment
+
+## Whom do we recruit?
+We recruit UG 1st years in the team, preferably after they have spent one semester on the campus. We can also recruit any 2nd year in their third semester, based on recommendations by the members.
+
+## How do we recruit?
+For more detailed description, refer [Freshers' Selection](/docs/events/freshers-selection)
+
+## Do we accept M.Tech and Ph.D students?
+By acceptance, we mean that they will hold a number of responsibilities
+- Attend our meetings
+- Participate in our workshops and their logistics
+- Collaborate on projects together
+- Be a great team member
+
+However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If you want to talk about something, you can invite them to one of your meetings as well. There are no such rules.

--- a/community/recruitment.md
+++ b/community/recruitment.md
@@ -15,6 +15,6 @@ By acceptance, we mean that they will hold a number of responsibilities
 - Attend our meetings
 - Participate in our workshops and their logistics
 - Collaborate on projects together
-- Be a great team member
+- Be an active member of the society
 
 However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If they want to talk about something, we can have them in one of your meetings as well. There are no such rules preventing the same.

--- a/community/recruitment.md
+++ b/community/recruitment.md
@@ -17,4 +17,4 @@ No. By acceptance, we mean that they will hold a number of responsibilities
 - Collaborate on projects together
 - Be an active member of the society
 
-However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If they want to talk about something, we can have them in one of our meetings as well.
+However, we have been collaborating with non-KOSS members since forever. They are welcome to join/lead our events or pitch something to us. If they want to talk about something, we can have them in one of our meetings as well.

--- a/community/recruitment.md
+++ b/community/recruitment.md
@@ -11,7 +11,7 @@ We recruit UG 1st years in the team, preferably after they have spent one semest
 For more detailed description, refer [Freshers' Selection](/docs/events/freshers-selection)
 
 ## Do we accept M.Tech and Ph.D students?
-By acceptance, we mean that they will hold a number of responsibilities
+No. By acceptance, we mean that they will hold a number of responsibilities
 - Attend our meetings
 - Participate in our workshops and their logistics
 - Collaborate on projects together

--- a/community/recruitment.md
+++ b/community/recruitment.md
@@ -17,4 +17,4 @@ By acceptance, we mean that they will hold a number of responsibilities
 - Collaborate on projects together
 - Be a great team member
 
-However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If you want to talk about something, you can invite them to one of your meetings as well. There are no such rules.
+However, we have been collaborating with non-KOSS members since forever. They are welcoming to join/lead our events or pitch something to us. If they want to talk about something, we can have them in one of your meetings as well. There are no such rules preventing the same.


### PR DESCRIPTION
Signed-off-by: rakaar <rka87338@gmail.com>

Added docs
- `/community/recruitment`

**Justify your changes or addition.**
As per @xypnox's [suggestion](https://github.com/kossiitkgp/docs/issues/33) to add a separate section for recruitment, added a separate file and linked to the index page. The content of the file `community/recruitment.md` gathers the data related to recruitment queries at one place. 

**Why do you think it should be documented?**
We get queries related to recruitment very often, hence docs will serve a great purpose for those who are interested to know about it.  We can request the websites/apps to directly link to our docs, where they have sometimes have the wrong information.