### PR TITLE
Add KWoC Manuals as Markdown Documents

### DIFF
--- a/events/kwoc/2022/mentor-manual-2022.md
+++ b/events/kwoc/2022/mentor-manual-2022.md
@@ -1,0 +1,41 @@
+# Kharagpur Winter of Code 2022
+## Mentor Manual
+
+### Introduction
+#### What is Kharagpur Winter of Code?
+[Kharagpur Winter of Code](http://kwoc.kossiitkgp.org/) is an initiative by Kharagpur Open Source Society ([KOSS](http://kossiitkgp.org/)) for the students, who have little or no experience in open source software development, to get them involved during the winter vacations and break the ice of Open Source contributions. All of the work is going to be on [GitHub](https://github.com).
+
+KWoC is modeled to be similar to but smaller in scope than [Google Summer of Code](https://summerofcode.withgoogle.com/archive/), [Outreachy](https://www.outreachy.org), [Season of KDE](https://season.kde.org), [Rails Girls Summer of Code](https://railsgirlssummerofcode.org), [GirlScript Summer of Code](https://gssoc.girlscript.tech) and many similar programs. KWoC similarly, is aimed at introducing new students to the area and helping them make PRs, in fact, a first for many of them, and also gaining confidence which will help them continue their open source journey.
+
+#### Goals of the program
+As a mentor, you must know that the primary goal of the program is to help new students to understand the paradigm of open source contribution and increase their expertise level on Git and GitHub.
+
+#### Eligibility
+There are five main criteria to be a mentor in KWoC:
+1. You must have one or more projects on GitHub with merge access.
+2. Your project(s) have more than two easy-to-fix and at least one moderate level issue.
+3. You must have a dedicated public communication channel for each project, where all the conversations regarding the project will happen.
+4. Your project must have a descriptive README.
+5. KWoC organizers approve your project(s).
+
+### Why should I apply?
+#### Boost your project
+Do you have a project which you had started months ago and now you don’t find time to add new features to it or fix small issues? - You can think of applying. For the students, it’s about the contributions. And for you, it’s about keeping your project alive and going strong!
+
+#### Nurture your idea into reality
+Do you have an idea in your mind about a small or significant utility and want to make it real this December?. You can lay the groundwork and use the help of interested students to convert your idea into reality.
+
+
+### Applying
+#### Create a communication channel for your project
+All the conversations between the mentor and the students who are working on the project should be on a public channel. It could be a Google group, IRC channel, Slack/Gitter/Matrix channel or any other communication platform that allows a team to interact and work collaboratively. Make sure to add the link to this communication channel in the registration form!
+
+#### Make the project descriptive and beginner friendly
+- Every kick-ass project needs to have a kick-ass README file. Go ahead and add a beautiful and detailed README to your project so that beginners can find it easy to get started with your project.
+- You may add an action plan and a good proposal about what you aim to finish up by the end of KWoC. This will help applicants see a larger picture of what they can try developing instead of just fixing a couple of issues. You can add this abstract to the README file or the description of your project on GitHub. This is optional; the acceptance of your project doesn’t depend on the action plan, although we believe it’ll be of great help to the participants.
+
+
+#### Register on the KWoC website
+Go to the website of KWoC - http://kwoc.kossiitkgp.org. The registration link is on the homepage!.
+Contact
+For any queries, write an email to admin@kossiitkgp.org Website: https://kossiitkgp.org/

--- a/events/kwoc/2022/student-manual-2022.md
+++ b/events/kwoc/2022/student-manual-2022.md
@@ -1,0 +1,101 @@
+# Kharagpur Winter of Code 2022
+## Student Manual
+### Introduction
+#### What is Kharagpur Winter of Code?
+You have seen the [website](https://kwoc.kossiitkgp.org) of KWoC, you have heard your friends talking about it, you have seen the posters all over the place and now you want to know more about it. That’s great! So, here we go:
+
+Kharagpur Winter of Code is an initiative by Kharagpur Open Source Society ([KOSS](https://kossiitkgp.org)) for getting students having little to no experience in open source software development involved in Open Source contributions.
+
+KWoC is modeled to be similar to but smaller in scope than [Google Summer of Code](https://summerofcode.withgoogle.com/archive/), [Outreachy](https://www.outreachy.org), [Season of KDE](https://season.kde.org), [Rails Girls Summer of Code](https://railsgirlssummerofcode.org), [GirlScript Summer of Code](https://gssoc.girlscript.tech). KWoC matches interested students with open source projects looking for contributions.
+
+Students work through the winter to contribute code and documentation to the project(s). Through their work, students are exposed to open source culture and gain experience in software development and collaborative work. We, at KOSS, promote open source through this event every year.
+
+**NOTE: KOSS does not provide any form of stipend to students taking part in KWoC. It is a program purely for learning purposes.**
+
+Registered students will have to choose one or more projects from the list, which will be released on 6th December 2021. Every project list will have at least one mentor and an Ideas Page. The Ideas Page will contain the possible work to be done on the project. Students will then contact the mentor who shall guide them on the project and continue discussing their plan for the winter.
+
+#### Goals of the program
+The primary goals of KWoC are:
+- Inspire young developers to get involved in Open Source software development.
+- Help them to master the development workflow of Git and GitHub.
+- Connect students with mentors.
+
+### Why should I apply?
+Well, now you know that Kharagpur Winter of Code seems like something productive to do this December. But why shouldn’t I just go on a trip? Well, here are some of the reasons why you should apply for it.
+
+#### An absolutely amazing working experience on projects
+KWoC is a place where you get to use your current skill set on existing projects. Working in collaboration with other people on an open source project is probably something new to you.
+
+#### Acquiring new skill sets
+While you’ll be adding your piece of code to the existing piece of software, you will get to learn the structure of the software and more about the process of creating it from scratch. That, in the future, will help you in creating your own software.
+
+#### Building your network
+While being a part of KWoC, you will have healthy conversations with many helpful and talented mentors. This will help you build your network in your early days itself. You can then approach them any time after the program ends. They remain with you, in your connections.
+
+#### Sense of achievement
+It feels really great to have your first patch submitted. It feels like an achievement when your contribution goes online and is ready to be helpful to other folks throughout the world.
+
+#### For the love of code and open source
+If you love to code and it relates even distinctly to your passion, then you will find an opportunity to express that love by being a part of the Kharagpur Winter of Code.
+
+### Am I Good Enough?
+In the past few years, a few first-year students from KGP have made their way to GSoC. If they can, this simply rules out myths like first years are not meant for it. The skills you need to be a part of it are:
+
+#### Requirements:
+##### Working setup
+A working laptop/computer with internet throughout the program.
+Most of the time, you will be coding and pushing your code online. This requires you to have a computer and a working internet connection with you.
+Pro-Tip: Don’t be afraid if you don’t have a Linux operating system; your mentor is there to help you out!
+
+##### Communication Skills
+You will have to speak up. You will have to email the project mentor. You will have to submit your query to KOSS in case of any issue or facing difficulty in understanding anything. As long as you can express yourself, there is nothing to stop you from achieving it.
+
+### How to apply?
+#### Joining GitHub
+Go to https://github.com and Sign Up. Choose a cool username (commonly referred to as GitHub handle) for yourself, and voila! You’re ready to dive into the world of open source!
+
+#### Registration on KWoC website
+Go to the website of KWoC - http://kwoc.kossiitkgp.org and find the “Student Registration” button at the center of the page. Login with GitHub and fill in your name, email address and  Institute. Hoorah! You’re in (Hackerman.jpg).
+
+### What to do next?
+#### Choosing a project
+First of all, choose the project(s) that you would like to work on in KWoC. You are free to contribute to as many projects as you like. Navigate over to https://kwoc.kossiitkgp.org/projects and hunt down projects by their description. All of the projects must be on GitHub. Learn how to get acquainted with GitHub’s interface with the help of various online resources, some of which are mentioned on the dashboards.
+
+#### Making contact
+The contact details of each mentor will be available to you on the projects list. Feel free to contact the mentors to know more about their project.
+
+#### Software Development
+Develop the project codebase. Write up test suites. Add third-party integrations. And lots of other cool stuff depending on your project. After cooking up the perfect recipe, use Git to keep track of the changes and create your Pull Requests.
+
+GitHub. Fix as many issues as you can and add as many new features as possible to the project. Communicate with your mentor about further requirements and/or improvements
+
+#### Writing documentation
+The code that you have added must be documented thoroughly. Open Source involves writing code that humans can read and
+understand. Good documentation makes it easier to understand the code. Hence, add information in README, in the comments of code, etc. Ask your mentor to help you out with it.
+
+#### Asking Questions
+More often than not, mentors find it difficult to answer vague questions and tend to ignore them, considering the student is not very interested (even if you are!). We have two great articles for you. Do give them a read:
+- Stackoverflow’s [How do I ask good questions](https://stackoverflow.com/help/how-to-ask)
+- Eric S. Raymond’s [How to ask questions the smart way](http://www.catb.org/esr/faqs/smart-questions.html)
+
+### Wrapping up
+#### Mid Evals
+By 20th Dec 2021, you should have at least 1 commit in the project(s) you’re working on. In other words, it means you have made at least 1 meaningful contribution to the project.
+
+#### Stats Board
+The leader board, which displays all the activities by registered students in KOSS, is live at
+http://kwoc.kossiitkgp.org/stats/student. It represents the activity board of every student registered in KWoC. KOSS monitors the Stats board and various sorting options are available (by commits being the default one).
+
+#### Report Submission
+At the end of the 5 weeks, you will have to create a report. Failing to do so, will not result in successful participation.
+The report can be as descriptive as you want but must contain at least the following points:
+- List of projects you worked on
+- List of Pull Requests you created
+- Summary of your work
+- Learnings
+
+### Contact
+For any queries, write an email to admin@kossiitkgp.org or feel free to post on #queries channel of our Slack workspace
+Website: https://kossiitkgp.org/
+
+Acknowledgment: Huge thanks to the authors of the [GSoC Student Guide](https://google.github.io/gsocguides/student/). The guide serves very well for referencing the outline of the KWoC Student guide.


### PR DESCRIPTION
### Notes:
- Read [.github/CONTRIBUTING.md](https://github.com/kossiitkgp/docs/blob/master/.github/CONTRIBUTING.md) before creating the Pull Request. This is a MUST.
- KOSS Documentation is public. Make sure you are not adding any information which should remain private.

**Write path(s) which will be affected by this Pull Request.**
Example:
- `/events/`

**Justify your changes or addition.**
Added KWoC mentor and student manuals as markdown documents.

**Why do you think it should be documented?**
Easier to maintain as markdown documents which can be later converted to other formats such as PDF.

Will sharing this with just the current members serve our purpose? For example, how you plan to conduct an event next week is a private affair. But, how you generally do the event, should be documented.
