### PR TITLE
docs: added executives team on gh

### DIFF
--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -22,6 +22,7 @@ toc=true
 
 1. Make all Executives the Admins of Slack workspace.
 1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
+1. Replace all members of the `Executives` team on the Github org with the new executives.
 1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as `Owners`.
 1. Make Executive Heads the Managers of the Google Group.
 1. [Transfer access](./socials.md#transferring-access) of Social media accounts.


### PR DESCRIPTION
**Write path(s) which will be affected by this Pull Request.**
Example:
- `/community/oboarding-offboarding`

**Justify your changes or addition.**
- A new "Executives" team was added on Github that is used to ping or request all executives for review instead of individually. This change updates the promotion section to include the replacement of the members of this team.

**Why do you think it should be documented?**
- To keep the team updated.

Will sharing this with just the current members serve our purpose? For example, how you plan to conduct an event next week is a private affair. But, how you generally do the event, should be documented.
