### PR TITLE
Added 2FA Enforcement for Executives

### DIFF
--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -21,6 +21,7 @@ toc=true
 ## How to re-designate Core Team Members as Executives?
 
 1. Make all Executives the Admins of Slack workspace.
+1. Make all new executives enable two-factor authentication on their Github accounts before proceeding with the further steps. The following steps give access to crucial organization repositories and settings.
 1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
 1. Replace all members of the `Executives` team on the Github org with the new executives.
 1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as `Owners`.


### PR DESCRIPTION
**Write path(s) which will be affected by this Pull Request.**
Example:
- `/community/onboarding-offboarding.md`

**Justify your changes or addition.**
- We believe 2FA is a must for executives as they have access to everything in the organization.
- It would be good to enforce 2FA when CTMs are redesignated as executives.
- It would also be nice to encourage CTMs to enable 2FA but as some of their accounts will be new, this setting can not be enforced organization-wide. Also, enforcing this setting would kick previous members, so adding this to the docs felt like the best option.
