### PR TITLE
Updated Onboarding, Offboarding, and Socials

### DIFF
--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -19,7 +19,7 @@ toc=true
 1. Create a Whatsapp group with the Executives + CTMs and name it `KOSS XX` where `XX` is the sum of the last two digits of the batch years of the executives and CTMs. Eg: Batch of '21 and batch of '22 will have a whatsapp group named `KOSS 43`. (Credits to [@rakaar](https://github.com/rakaar) for the naming scheme).
 1. Create a Whatsapp group with all the advisors (B.Tech and Dual), Executives, and CTMs, and name it `KOSS XX` where `XX` is the sum of the last two digits of their batch years.
 1. Add both of the above groups to the `Kossverse` Whatsapp community.
-1. The purpose of the Whatsapp groups is promotions, bakaar, and motiviation to use Slack. This should be made clear to the new members and they should be encouraged to use Slack as the main medium of communication.
+1. The purpose of the Whatsapp groups is promotions, bakaar, and motivation to use Slack. It will be an unofficial platform for communcation. This should be made clear to the new members and they should be encouraged to use Slack as the main medium of communication.
 
 ## How to re-designate Core Team Members as Executives?
 1. Make all Executives the Admins of Slack workspace and add them to the `#emails` channel. 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -7,7 +7,7 @@ toc=true
 ## How to onboard someone in KOSS?
 1. Add them to the “Newbies” GitHub team.
 1. Add them to the kossiitkgp@ Google Group. Check the delivery settings. Anyone can ask to join using this link https://groups.google.com/g/kossiitkgp
-1. Add them to the Slack. Ask each one to install the Slack desktop and mobile apps and enable notifications to not miss out any important updates.
+1. Add them to the Slack. Make them install the Slack desktop and mobile apps and enable notifications to not miss out any important updates.
 1. Add them to their batch’s private channel.
 1. Add their contact details on https://github.com/kossiitkgp/secrets.
 1. Update the [Bhattu bot](https://github.com/kossiitkgp/bhattu) with the new batch's Slack accounts.

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -41,10 +41,13 @@ toc=true
 1. Remove them from the GitHub organization.
 1. Disable their account on Slack (Contact an owner if they are admin).
 1. Remove them from the Google group (Contact owners of group).
-1. Update the Contacts on https://github.com/kossiitkgp/secrets .
-1. Update the “Members” section on the website - https://kossiitkgp.org .
+1. Update the Contacts on https://github.com/kossiitkgp/secrets.
+1. Update the “Members” section on the website - https://kossiitkgp.org.
 1. Remove access to KOSS’ facebook page.
-1. Remove their access to KOSS gsuite account and other Social Media Handles.
+1. Remove their access to KOSS gsuite account if they have access.
+1. Update any passwords they had access to. Notify the password change on Slack.
+1. [Revoke acess](./socials.md#revoking-access-for-offboarding) from social media accounts.
+
 
 ## Why do we lay off some members? What are the reasons?
 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -13,7 +13,6 @@ toc=true
 1. Add their contact details on https://github.com/kossiitkgp/secrets.
 1. Assign their 1:1 group.
 1. Add their name to the website.
-1. Add them to facebook groups (unofficial)
 1. Give access to KOSS’s facebook page.
 1. Make them store numbers of everyone in team using the automatically generated VCFs in the secrets repository. 
 
@@ -45,7 +44,6 @@ toc=true
 1. Update the Contacts on https://github.com/kossiitkgp/secrets .
 1. Update the “Members” section on the website - https://kossiitkgp.org .
 1. Remove access to KOSS’ facebook page.
-1. Remove them from facebook groups (if any).
 1. Remove their access to KOSS gsuite account and other Social Media Handles.
 
 ## Why do we lay off some members? What are the reasons?

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -26,7 +26,7 @@ toc=true
 1. Add all Executives to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
 1. Replace all members of the `Executives` team on the Github org with the new executives.
 1. Ask an Owner of kossiitkgp GitHub org to change role of Executives as `Owners`.
-1. Make Executive Heads the Managers of the Google Group.
+1. Make Executives the Managers of the Google Group.
 1. [Transfer access](./socials.md#transferring-access) of Social media accounts.
 1. Release the names from blog/facebook page.
 1. Update the “Members” section on the website.

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -10,28 +10,27 @@ toc=true
 1. Add them to the kossiitkgp@ Google Group. Check the delivery settings. Anyone can ask to join using this link https://groups.google.com/g/kossiitkgp
 1. Add them to the Slack.
 1. Add them to their batch’s private channel.
-1. Add their contact details on https://github.com/kossiitkgp/secrets .
+1. Add their contact details on https://github.com/kossiitkgp/secrets.
 1. Assign their 1:1 group.
 1. Add their name to the website.
 1. Add them to facebook groups (unofficial)
 1. Give access to KOSS’s facebook page.
 1. Make them store numbers of everyone in team.
-1. Add them to [KOSS Workshops](https://teams.microsoft.com/l/team/19%3aa012c782fe2d428ab5bf644ef564efe5%40thread.tacv2/conversations?groupId=5fa16cd8-ce71-4c62-b41c-22816c93f841&tenantId=71dbb522-5704-4537-9f25-6ad2dcd4278d) Microsoft Team and make them Owner (Applicable for online workshop conduction)
 
 ## How to re-designate Core Team Members as Executives?
 
 1. Make all Executives the Admins of Slack workspace and add them to the `#emails` channel. 
 1. Make all new executives enable two-factor authentication on their Github accounts before proceeding with the further steps. The following steps give access to crucial organization repositories and settings.
-1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
+1. Add all Executives to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
 1. Replace all members of the `Executives` team on the Github org with the new executives.
-1. Ask an Owner of kossiitkgp GitHub org to change role of Executive Heads as `Owners`.
+1. Ask an Owner of kossiitkgp GitHub org to change role of Executives as `Owners`.
 1. Make Executive Heads the Managers of the Google Group.
 1. [Transfer access](./socials.md#transferring-access) of Social media accounts.
 1. Update Contacts README on `kossiitkgp/secrets`.
 1. Release the names from blog/facebook page.
 1. Update the “Members” section on the website.
 
-## How to re-designate Executive Members as Advisors?
+## How to re-designate Executives as Advisors?
 
 1. Make all Advisors the Owners of Slack workspace.
 1. Make all Advisors the Owners of the Google Group.
@@ -48,7 +47,6 @@ toc=true
 1. Update the “Members” section on the website - https://kossiitkgp.org .
 1. Remove access to KOSS’ facebook page.
 1. Remove them from facebook groups (if any).
-1. Remove them from owner position in KOSS Workshops Microsoft Team.
 1. Remove their access to KOSS gsuite account and other Social Media Handles.
 
 ## Why do we lay off some members? What are the reasons?

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -17,7 +17,7 @@ toc=true
 1. Make them store numbers of everyone in team using the automatically generated VCFs in the secrets repository.
 1. Ask them to create their batch's private Whatsapp group and add it to the "Kossverse" community. 
 1. Create a Whatsapp group with the Executives + CTMs and name it `KOSS XX` where `XX` is the sum of the last two digits of the batch years of the executives and CTMs. Eg: Batch of '21 and batch of '22 will have a whatsapp group named `KOSS 43`. (Credits to [@rakaar](https://github.com/rakaar) for the naming scheme).
-1. Create a Whatsapp group with all the advisors (B.Tech and Dual), Executives, and CTMs, and name it `KOSS XX` where `XX` is the sum of the last two digits of their batch years.
+1. Create a Whatsapp group with all the on-campus advisors (Last two batches, B.Tech and Dual), Executives, and CTMs, and name it `KOSS XX` where `XX` is the sum of the last two digits of their batch years.
 1. Add both of the above groups to the `Kossverse` Whatsapp community.
 1. The purpose of the Whatsapp groups is promotions, bakaar, and motivation to use Slack. It will be an unofficial platform for communcation. This should be made clear to the new members and they should be encouraged to use Slack as the main medium of communication.
 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -5,7 +5,6 @@ toc=true
 # Onboarding/Offboarding
 
 ## How to onboard someone in KOSS?
-
 1. Add them to the “Newbies” GitHub team.
 1. Add them to the kossiitkgp@ Google Group. Check the delivery settings. Anyone can ask to join using this link https://groups.google.com/g/kossiitkgp
 1. Add them to the Slack.
@@ -14,10 +13,13 @@ toc=true
 1. Assign their 1:1 group.
 1. Add their name to the website.
 1. Give access to KOSS’s facebook page.
-1. Make them store numbers of everyone in team using the automatically generated VCFs in the secrets repository. 
+1. Make them store numbers of everyone in team using the automatically generated VCFs in the secrets repository.
+1. Ask them to create their batch's private Whatsapp group and add it to the "Kossverse" community. Encourage them to use Slack as the main medium of communication and keep Whatsapp for emergencies only.
+1. Create a Whatsapp group with the Executives + CTMs and name it `KOSS XX` where `XX` is the sum of the last two digits of the batch years of the executives and CTMs. Eg: Batch of '21 and batch of '22 will have a whatsapp group named `KOSS 43`. (Credits to [@rakaar](https://github.com/rakaar) for the naming scheme).
+1. Create a Whatsapp group with all the advisors (B.Tech and Dual), Executives, and CTMs, and name it `KOSS XX` where `XX` is the sum of the last two digits of their batch years.
+1. Add both of the above groups to the `Kossverse` Whatsapp community.
 
 ## How to re-designate Core Team Members as Executives?
-
 1. Make all Executives the Admins of Slack workspace and add them to the `#emails` channel. 
 1. Make all new executives enable two-factor authentication on their Github accounts before proceeding with the further steps. The following steps give access to crucial organization repositories and settings.
 1. Add all Executives to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
@@ -27,9 +29,9 @@ toc=true
 1. [Transfer access](./socials.md#transferring-access) of Social media accounts.
 1. Release the names from blog/facebook page.
 1. Update the “Members” section on the website.
+1. Make a few randomly chosen executives admins of the "Kossverse" Whatsapp community while removing the graduating admins. There is a limit of 20 admins.
 
 ## How to re-designate Executives as Advisors?
-
 1. Make all Advisors the Owners of Slack workspace.
 1. Make all Advisors the Owners of the Google Group.
 1. Add all new Advisors to the `Advisors` team on GitHub and move graduated advisors to the `Alumni` team. 
@@ -37,7 +39,6 @@ toc=true
 1. Update the “Members” section on the website.
 
 ## How to offboard someone from KOSS?
-
 1. Remove them from the GitHub organization.
 1. Disable their account on Slack (Contact an owner if they are admin).
 1. Remove them from the Google group (Contact owners of group).
@@ -47,7 +48,7 @@ toc=true
 1. Remove their access to KOSS gsuite account if they have access.
 1. Update any passwords they had access to. Notify the password change on Slack.
 1. [Revoke acess](./socials.md#revoking-access-for-offboarding) from social media accounts.
-
+1. Remove them from the "Kossverse" Whatsapp community and any official KOSS Whatsapp groups.
 
 ## Why do we lay off some members? What are the reasons?
 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -7,17 +7,18 @@ toc=true
 ## How to onboard someone in KOSS?
 1. Add them to the “Newbies” GitHub team.
 1. Add them to the kossiitkgp@ Google Group. Check the delivery settings. Anyone can ask to join using this link https://groups.google.com/g/kossiitkgp
-1. Add them to the Slack.
+1. Add them to the Slack. Ask each one to install the Slack desktop and mobile apps and enable notifications to not miss out any important updates.
 1. Add them to their batch’s private channel.
 1. Add their contact details on https://github.com/kossiitkgp/secrets.
 1. Assign their 1:1 group.
 1. Add their name to the website.
 1. Give access to KOSS’s facebook page.
 1. Make them store numbers of everyone in team using the automatically generated VCFs in the secrets repository.
-1. Ask them to create their batch's private Whatsapp group and add it to the "Kossverse" community. Encourage them to use Slack as the main medium of communication and keep Whatsapp for emergencies only.
+1. Ask them to create their batch's private Whatsapp group and add it to the "Kossverse" community. 
 1. Create a Whatsapp group with the Executives + CTMs and name it `KOSS XX` where `XX` is the sum of the last two digits of the batch years of the executives and CTMs. Eg: Batch of '21 and batch of '22 will have a whatsapp group named `KOSS 43`. (Credits to [@rakaar](https://github.com/rakaar) for the naming scheme).
 1. Create a Whatsapp group with all the advisors (B.Tech and Dual), Executives, and CTMs, and name it `KOSS XX` where `XX` is the sum of the last two digits of their batch years.
 1. Add both of the above groups to the `Kossverse` Whatsapp community.
+1. The purpose of the Whatsapp groups is promotions, bakaar, and motiviation to use Slack. This should be made clear to the new members and they should be encouraged to use Slack as the main medium of communication.
 
 ## How to re-designate Core Team Members as Executives?
 1. Make all Executives the Admins of Slack workspace and add them to the `#emails` channel. 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -35,6 +35,7 @@ toc=true
 
 1. Make all Advisors the Owners of Slack workspace.
 1. Make all Advisors the Owners of the Google Group.
+1. Add all new Advisors to the `Advisors` team on GitHub and move graduated advisors to the `Alumni` team. 
 1. Update Contacts README on `kossiitkgp/secrets`.
 1. Update the “Members” section on the website.
 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -15,7 +15,7 @@ toc=true
 1. Add their name to the website.
 1. Add them to facebook groups (unofficial)
 1. Give access to KOSS’s facebook page.
-1. Make them store numbers of everyone in team.
+1. Make them store numbers of everyone in team using the automatically generated VCFs in the secrets repository. 
 
 ## How to re-designate Core Team Members as Executives?
 
@@ -26,7 +26,6 @@ toc=true
 1. Ask an Owner of kossiitkgp GitHub org to change role of Executives as `Owners`.
 1. Make Executive Heads the Managers of the Google Group.
 1. [Transfer access](./socials.md#transferring-access) of Social media accounts.
-1. Update Contacts README on `kossiitkgp/secrets`.
 1. Release the names from blog/facebook page.
 1. Update the “Members” section on the website.
 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -48,7 +48,7 @@ toc=true
 1. Update the “Members” section on the website - https://kossiitkgp.org.
 1. Remove access to KOSS’ facebook page.
 1. Remove their access to KOSS gsuite account if they have access.
-1. Update any passwords they had access to. Notify the password change on Slack.
+1. Change any passwords they had access to and update the [passwords](https://github.com/kossiitkgp/passwords) repository. Notify the password change on Slack.
 1. [Revoke acess](./socials.md#revoking-access-for-offboarding) from social media accounts.
 1. Remove them from the "Kossverse" Whatsapp community and any official KOSS Whatsapp groups.
 

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -20,7 +20,7 @@ toc=true
 
 ## How to re-designate Core Team Members as Executives?
 
-1. Make all Executives the Admins of Slack workspace.
+1. Make all Executives the Admins of Slack workspace and add them to the `#emails` channel. 
 1. Make all new executives enable two-factor authentication on their Github accounts before proceeding with the further steps. The following steps give access to crucial organization repositories and settings.
 1. Add all Executive Members and Heads to the `Admins` team on GitHub org. Remove them from the `Newbies` team.
 1. Replace all members of the `Executives` team on the Github org with the new executives.

--- a/community/onboarding-offboarding.md
+++ b/community/onboarding-offboarding.md
@@ -10,6 +10,7 @@ toc=true
 1. Add them to the Slack. Ask each one to install the Slack desktop and mobile apps and enable notifications to not miss out any important updates.
 1. Add them to their batch’s private channel.
 1. Add their contact details on https://github.com/kossiitkgp/secrets.
+1. Update the [Bhattu bot](https://github.com/kossiitkgp/bhattu) with the new batch's Slack accounts.
 1. Assign their 1:1 group.
 1. Add their name to the website.
 1. Give access to KOSS’s facebook page.

--- a/community/socials.md
+++ b/community/socials.md
@@ -6,6 +6,7 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 - [Instagram](https://www.instagram.com/kossiitkgp/)
 - [Twitter](https://twitter.com/kossiitkgp)
 - [LinkedIn](https://www.linkedin.com/company/kharagpur-open-source-society)
+- [Whatsapp Channel](https://whatsapp.com/channel/0029VaR3Adf8vd1TKOUtCo3W)
 
 ### Post Release Guidelines
 - Try to include a poster in every post. **NOTE: Instagram posts cannot be shared without an image.**
@@ -17,6 +18,10 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
     - The post content must be shortened to include only the most essential information.
     - Try to include the most relevant information in the main tweet.
     - A poster, if present, must only be added to the main tweet of the thread.
+- Whatsapp guidelines:
+    - The image has to have a 1:1 ratio to be properly displayed in messages without clicking.
+    - [This](https://pinetools.com/blurred-frame-images-generator) tool may be used to add blurred borders to the image to make it 1:1.
+    - The Whatsapp channel may be used for sharing posts regarding KOSS events as well as important open-source community news (eg: GSoC announcements) or interesting articles to keep the community engaged. Do not share too many posts as it leads to spam.
 
 ### Resharing/Reposting Guidelines
 - Posts from organizations such as MetaKGP that align with the views of KOSS or relevant posts from other KOSS members can be reshared/reposted from KOSS social media accounts.
@@ -57,6 +62,8 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 - Instagram and Twitter accounts must be logged into to make a post.
 - The credentials to these accounts will already have been shared with the new executives.
 
+#### Whatsapp Channel
+
 ### Revoking Access (For Offboarding)
 #### Facebook and LinkedIn
 - An existing executive or advisor with access to the page revokes access from the pages.
@@ -65,3 +72,5 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 #### Instagram and Twitter
 - If the said member had access to these socials, update their passwords.
 - Notify the password change on Slack.
+
+#### Whatsapp Channel

--- a/community/socials.md
+++ b/community/socials.md
@@ -63,6 +63,7 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 - The credentials to these accounts will already have been shared with the new executives.
 
 #### Whatsapp Channel
+- This is not clear as of now as it is an experimental Whatsapp feature.
 
 ### Revoking Access (For Offboarding)
 #### Facebook and LinkedIn
@@ -74,3 +75,4 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 - Notify the password change on Slack.
 
 #### Whatsapp Channel
+- This is not clear as of now as it is an experimental Whatsapp feature.

--- a/community/socials.md
+++ b/community/socials.md
@@ -56,3 +56,12 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 #### Instagram and Twitter
 - Instagram and Twitter accounts must be logged into to make a post.
 - The credentials to these accounts will already have been shared with the new executives.
+
+### Revoking Access (For Offboarding)
+#### Facebook and LinkedIn
+- An existing executive or advisor with access to the page revokes access from the pages.
+- See the [Transferring Access](#transferring-access) section for links to help articles for the same.
+
+#### Instagram and Twitter
+- If the said member had access to these socials, update their passwords.
+- Notify the password change on Slack.

--- a/community/socials.md
+++ b/community/socials.md
@@ -71,7 +71,7 @@ Guidelines regarding handling, releasing posts, and transferring access to the o
 - See the [Transferring Access](#transferring-access) section for links to help articles for the same.
 
 #### Instagram and Twitter
-- If the said member had access to these socials, update their passwords.
+- If the said member had access to these socials, change their passwords and update the [passwords](https://github.com/kossiitkgp/passwords) repository.
 - Notify the password change on Slack.
 
 #### Whatsapp Channel


### PR DESCRIPTION
**Write path(s) which will be affected by this Pull Request.**
Example:
- `/community/socials.md`
- `/community/onboarding-offboarding.md`

**Justify your changes or addition.**
- Made `Advisors` and `Alumni` teams official. Each year the teams will be updated. This can be useful for searching KOSS members easily and for requesting reviews by the whole team instead of individuals.
- New executives should be added to the `#emails` channel on Slack. This part of the promotion process can be updated in the future to include other privileged channels.
- Replaced "Executive Heads" and "Members" everywhere with "Executives" for consistency. The decision about not designating executives as heads and members still persists at the end.
- The secrets repo related procedures have been updated as new automations have been added.
- Deprecated Facebook groups and the MS Teams workshops team as they were no longer used.
- Added a section in `socials.md` describing procedures for revoking access from offboarded members.
- Made Whatsapp groups, the community, and the Whatsapp channels official.

Please provide any inputs in the comments below. If and once this PR is merged, the Advisors and Alumni teams can be updated.
